### PR TITLE
feat: add -s flag for configurable socket path

### DIFF
--- a/src/openvfsfuse/main.cpp
+++ b/src/openvfsfuse/main.cpp
@@ -42,7 +42,7 @@ namespace {
 void usage(char *name)
 {
     std::cerr << "Usage:" << std::endl //
-              << name << " [-h] | [-f] [-p] [-d] -i config-file -o ownerId /directory-mountpoint" << std::endl //
+              << name << " [-h] | [-f] [-p] [-d] [-s socket-path] -i config-file -o ownerId /directory-mountpoint" << std::endl //
               << "Type 'man openvfsfuse' for more details" << std::endl;
 }
 
@@ -57,7 +57,7 @@ std::optional<openVFSfuse_Args> processArgs(int argc, char *argv[])
 
     bool got_p = false;
 
-    while ((res = getopt(argc, argv, "hpfdi:o:")) != -1) {
+    while ((res = getopt(argc, argv, "hpfdi:o:s:")) != -1) {
         switch (res) {
         case 'h':
             usage(argv[0]);
@@ -89,6 +89,10 @@ std::optional<openVFSfuse_Args> processArgs(int argc, char *argv[])
         }
         case 'o':
             out.owner = optarg;
+            break;
+        case 's':
+            out.socketPath = optarg;
+            std::cout << "openVFSfuse using socket at " << optarg << std::endl;
             break;
         default:
             assert(false);

--- a/src/openvfsfuse/openvfsfuse.cpp
+++ b/src/openvfsfuse/openvfsfuse.cpp
@@ -727,6 +727,10 @@ static int openVFSfuse_removexattr(const char *orig_path, const char *name)
 
 int initializeOpenVFSFuse(openVFSfuse_Args &openVFSArgs)
 {
+    if (!openVFSArgs.socketPath.empty()) {
+        _socketThread.setSocketPath(openVFSArgs.socketPath);
+    }
+
     const auto contextInstance = std::make_unique<VFSFuseContext>(openVFSArgs);
 
     // First, check if the mount point has a xattr that shows that it's ours

--- a/src/openvfsfuse/openvfsfuse.h
+++ b/src/openvfsfuse/openvfsfuse.h
@@ -23,6 +23,7 @@ struct openVFSfuse_Args
     std::vector<std::string> fuseArgv;
     std::vector<std::string> appsNoHydrateFull; // these apps are not permitted to cause a dehydration
     std::vector<std::string> appsNoHydrateEndsWith;
+    std::string socketPath; // custom socket path (empty = default)
 };
 
 int initializeOpenVFSFuse(openVFSfuse_Args &openVFSArgs);

--- a/src/openvfsfuse/socketthread.h
+++ b/src/openvfsfuse/socketthread.h
@@ -80,6 +80,9 @@ public:
     /// Get thread name
     std::string GetThreadName() { return THREAD_NAME; }
 
+    /// Set the socket path (must be called before CreateThread)
+    void setSocketPath(const std::string &path) { _socketPath = path; }
+
 
 private:
     SocketThread(const SocketThread &) = delete;
@@ -113,7 +116,7 @@ private:
     std::future<void> m_threadStartFuture;
 
 
-    const std::string _socketPath{"/run/user/1000/OpenCloud/socket"};
+    std::string _socketPath{"/run/user/1000/OpenCloud/socket"};
     std::atomic<int> _socket;
 
     SharedMap &_sharedMap;


### PR DESCRIPTION
## Summary

The socket path is currently hardcoded to `/run/user/1000/OpenCloud/socket`, which prevents running multiple openvfs instances (e.g. one per cloud account or space) and assumes UID 1000.

This adds a `-s <socket-path>` command-line option that overrides the default. If not specified, the original default is used for backwards compatibility.

## Use case

Headless sync daemons (like [cloudd](https://codeberg.org/kosmos-eu/opencloud_cloudd)) need to run multiple openvfs instances with different socket paths, or use a socket path that matches their own configuration.

## Changes

- `main.cpp`: add `-s` to getopt, store in `openVFSfuse_Args.socketPath`
- `openvfsfuse.h`: add `socketPath` field to Args struct
- `openvfsfuse.cpp`: apply `socketPath` before socket thread creation
- `socketthread.h`: make `_socketPath` mutable, add `setSocketPath()`

4 files, +15/-3 lines.

## Test plan

- [x] Builds clean
- [x] `openvfs --help` shows `-s socket-path`
- [x] Without `-s`: uses default path (backwards compatible)