### PR TITLE
feat: add V2/INVALIDATE_PATH socket message for cache invalidation

### DIFF
--- a/src/openvfsfuse/openvfsfuse.cpp
+++ b/src/openvfsfuse/openvfsfuse.cpp
@@ -736,18 +736,17 @@ static int openVFSfuse_removexattr(const char *orig_path, const char *name)
 
 void openvfsfuse_invalidate_path(const std::string &path)
 {
-    if (_fuseInstance) {
-        // Prepend "/" if not absolute (internal paths are relative)
-        std::string fusePath = path;
-        if (!fusePath.empty() && fusePath[0] != '/') {
-            fusePath = "/" + fusePath;
-        }
-        int res = fuse_invalidate_path(_fuseInstance, fusePath.c_str());
-        if (res == 0 || res == -ENOENT) {
-            openvfsfuse_log(fusePath, "invalidate", 0, "path invalidated");
-        } else {
-            openvfsfuse_log(fusePath, "invalidate", res, "invalidate failed");
-        }
+    auto *ctx = fuse_get_context();
+    if (!ctx || !ctx->fuse) {
+        return;
+    }
+    const auto fusePath = getInternalPath(path);
+    std::string fuseStr = "/" + fusePath.string();
+    int res = fuse_invalidate_path(ctx->fuse, fuseStr.c_str());
+    if (res == 0 || res == -ENOENT) {
+        openvfsfuse_log(fuseStr, "invalidate", 0, "path invalidated");
+    } else {
+        openvfsfuse_log(fuseStr, "invalidate", res, "invalidate failed");
     }
 }
 

--- a/src/openvfsfuse/openvfsfuse.cpp
+++ b/src/openvfsfuse/openvfsfuse.cpp
@@ -147,6 +147,9 @@ std::string getcallername(fuse_context *context)
 static SharedMap _jobs;
 static SocketThread _socketThread("SocketThread", _jobs);
 
+// Global fuse pointer for invalidation from socket thread
+static struct fuse *_fuseInstance = nullptr;
+
 static int _transfer_id{12};
 
 
@@ -177,6 +180,12 @@ void openvfsfuse_log(const std::string &path, const char *action, int returncode
 static void *openVFSfuse_init(struct fuse_conn_info *, fuse_config *)
 {
     openvfsfuse_log("/path", "_init", 1, "**** INIT called");
+
+    // Store fuse instance for invalidation from socket thread
+    auto *ctx = fuse_get_context();
+    if (ctx) {
+        _fuseInstance = ctx->fuse;
+    }
 
     return NULL;
 }
@@ -723,6 +732,23 @@ static int openVFSfuse_removexattr(const char *orig_path, const char *name)
 {
     const auto path = getInternalPath(orig_path);
     return Xattr::removexattr(path, name);
+}
+
+void openvfsfuse_invalidate_path(const std::string &path)
+{
+    if (_fuseInstance) {
+        // Prepend "/" if not absolute (internal paths are relative)
+        std::string fusePath = path;
+        if (!fusePath.empty() && fusePath[0] != '/') {
+            fusePath = "/" + fusePath;
+        }
+        int res = fuse_invalidate_path(_fuseInstance, fusePath.c_str());
+        if (res == 0 || res == -ENOENT) {
+            openvfsfuse_log(fusePath, "invalidate", 0, "path invalidated");
+        } else {
+            openvfsfuse_log(fusePath, "invalidate", res, "invalidate failed");
+        }
+    }
 }
 
 int initializeOpenVFSFuse(openVFSfuse_Args &openVFSArgs)

--- a/src/openvfsfuse/openvfsfuse.h
+++ b/src/openvfsfuse/openvfsfuse.h
@@ -26,4 +26,5 @@ struct openVFSfuse_Args
 };
 
 int initializeOpenVFSFuse(openVFSfuse_Args &openVFSArgs);
+void openvfsfuse_invalidate_path(const std::string &path);
 void openvfsfuse_log(const std::string &path, const char *action, int returncode, const char *format, ...);

--- a/src/openvfsfuse/socketthread.cpp
+++ b/src/openvfsfuse/socketthread.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "socketthread.h"
+#include "openvfsfuse.h"
 #include "sharedmap.h"
 #include "strtools.h"
 
@@ -229,6 +230,15 @@ void SocketThread::handleReceivedMsg(const std::string &rawmsg)
                 } else {
                     cout << "Setting Job ID " << id << " to result " << res << endl;
                 }
+            }
+        } else if (msgType == "V2/INVALIDATE_PATH") {
+            try {
+                const auto j = json::parse(msgAttr);
+                const auto path = j["arguments"]["path"].get<string>();
+                cout << "Invalidating path: " << path << endl;
+                openvfsfuse_invalidate_path(path);
+            } catch (json::exception &e) {
+                std::cerr << "Invalid INVALIDATE_PATH message: " << msgAttr << e.what() << std::endl;
             }
         } else if (msgType == "VERSION") {
             vector<string> attribs = StrTools::split(msgAttr, ':');

--- a/src/openvfsfuse/socketthread.cpp
+++ b/src/openvfsfuse/socketthread.cpp
@@ -235,10 +235,10 @@ void SocketThread::handleReceivedMsg(const std::string &rawmsg)
             try {
                 const auto j = json::parse(msgAttr);
                 const auto path = j["arguments"]["path"].get<string>();
-                cout << "Invalidating path: " << path << endl;
+                openvfsfuse_log(path, "invalidate_path", 0, "received via socket");
                 openvfsfuse_invalidate_path(path);
             } catch (json::exception &e) {
-                std::cerr << "Invalid INVALIDATE_PATH message: " << msgAttr << e.what() << std::endl;
+                openvfsfuse_log("", "invalidate_path", -1, "invalid message: %s %s", msgAttr.c_str(), e.what());
             }
         } else if (msgType == "VERSION") {
             vector<string> attribs = StrTools::split(msgAttr, ':');


### PR DESCRIPTION
## Summary

When a sync daemon creates new placeholder files in the underlying filesystem after the FUSE mount is active, the kernel may cache negative lookups. New files don't appear in directory listings until the user navigates away and back.

This adds a new socket message that the sync daemon can send to invalidate a path in the FUSE kernel cache:

```
V2/INVALIDATE_PATH:{"arguments":{"path":"/subdir"}}
```

On receiving this message, openvfs calls `fuse_invalidate_path()` which clears the kernel's cached entries for that path. The next `readdir` or `lookup` will see the new files.

## Use case

Headless sync daemons like [cloudd](https://codeberg.org/kosmos-eu/opencloud_cloudd) periodically sync remote directory listings and create local placeholder files. Without cache invalidation, Nautilus and other file managers don't show new files until manual refresh.

## Changes

- `openvfsfuse.cpp`: store `fuse *` pointer during init, add `openvfsfuse_invalidate_path()` 
- `openvfsfuse.h`: declare `openvfsfuse_invalidate_path()`
- `socketthread.cpp`: handle `V2/INVALIDATE_PATH` message, call invalidate

3 files, +37 lines.

## Test plan

- [x] Builds clean
- [x] Existing socket protocol (VERSION, V2/HYDRATE_FILE) unaffected
- [ ] Integration test: create file in underlying FS, send INVALIDATE_PATH, verify ls shows it