### PR TITLE
Fix typo in json element requester

### DIFF
--- a/src/openvfsfuse/socketthread.cpp
+++ b/src/openvfsfuse/socketthread.cpp
@@ -137,7 +137,7 @@ bool SocketThread::socketSendMsg(std::shared_ptr<MsgData> msgData)
     }
 
     const json j = {
-        {"id", std::to_string(msgData->id)}, {"arguments", {{"file", msgData->file}, {"fileId", msgData->fileId}, {"requster", msgData->requester}}}};
+        {"id", std::to_string(msgData->id)}, {"arguments", {{"file", msgData->file}, {"fileId", msgData->fileId}, {"requester", msgData->requester}}}};
 
     msg += ":";
     msg += j.dump();


### PR DESCRIPTION
Fixes a name in the transfered JSON to the client. That member is not used so far.