### PR TITLE
Enable and disable general openvfs logging via -d switch

### DIFF
--- a/src/openvfsfuse/main.cpp
+++ b/src/openvfsfuse/main.cpp
@@ -77,6 +77,7 @@ std::optional<openVFSfuse_Args> processArgs(int argc, char *argv[])
         case 'd':
             // enable debug logging, implies -f
             out.fuseArgv.emplace_back("-d");
+            out.debugEnabled = true;
             std::cout << "openVFSfuse running with debug log enabled" << std::endl;
             break;
         case 'i': {

--- a/src/openvfsfuse/openvfsfuse.cpp
+++ b/src/openvfsfuse/openvfsfuse.cpp
@@ -55,6 +55,7 @@ public:
         , _rootHandle(open(_mountPoint.c_str(), 0))
         , _appsNoHydrateFull(args.appsNoHydrateFull)
         , _appsNoHydrateEndsWith(args.appsNoHydrateEndsWith)
+        , _debugEnabled(args.debugEnabled)
     {
         assert(!_instance);
 
@@ -100,6 +101,8 @@ public:
             || std::ranges::find_if(_appsNoHydrateEndsWith, [app](const auto &a) { return app.ends_with(a); }) != _appsNoHydrateEndsWith.cend();
     }
 
+    bool debugEnabled() const { return _debugEnabled; }
+
 private:
     static VFSFuseContext *_instance;
     std::filesystem::path _mountPoint;
@@ -107,6 +110,7 @@ private:
     int _rootHandle;
     std::vector<std::string> _appsNoHydrateFull;
     std::vector<std::string> _appsNoHydrateEndsWith;
+    bool _debugEnabled;
 };
 
 VFSFuseContext *VFSFuseContext::_instance = nullptr;
@@ -153,6 +157,9 @@ static int _transfer_id{12};
 
 void openvfsfuse_log(const std::string &path, const char *action, int returncode, const char *format, ...)
 {
+    if (!VFSFuseContext::instance().debugEnabled()) {
+        return;
+    }
     // FIXME - whitelist of pathes that are not logged at all?
     if (path == "./.OpenCloudSync.log")
         return;

--- a/src/openvfsfuse/openvfsfuse.h
+++ b/src/openvfsfuse/openvfsfuse.h
@@ -24,6 +24,7 @@ struct openVFSfuse_Args
     std::vector<std::string> fuseArgv;
     std::vector<std::string> appsNoHydrateFull; // these apps are not permitted to cause a dehydration
     std::vector<std::string> appsNoHydrateEndsWith;
+    bool debugEnabled = false; // checked in the central logging function if logging is enabled
 };
 
 int initializeOpenVFSFuse(openVFSfuse_Args &openVFSArgs);


### PR DESCRIPTION
So far the switch was passed to the fuse library but did not influence the logging behaviour of openvfs in general.

Now there is a check if debugging is enabled in the logging function.