### PR TITLE
Compare the caller's process, not its thread, to the client's

### DIFF
--- a/src/openvfsfuse/openvfsfuse.cpp
+++ b/src/openvfsfuse/openvfsfuse.cpp
@@ -120,6 +120,33 @@ auto getInternalPath(const std::string &path)
     return VFSFuseContext::instance().getInternalPath(path);
 }
 
+// FUSE reports the *thread* id of the caller in fuse_context::pid, while the
+// desktop client announces its process id over the socket API. A client that
+// writes the content it downloaded from a worker thread therefore fails the
+// identity check in openVFSfuse_open(), and its own write is treated as a
+// foreign access that needs hydrating -- which deadlocks the very hydration it
+// is answering.
+//
+// A thread of the client is visible as /proc/<pid>/task/<tid>, so one stat()
+// answers the question without reading or parsing anything. On platforms
+// without /proc only the direct comparison applies, which is what was there
+// before.
+bool callerBelongsToProcess(pid_t callerThreadId, long processId)
+{
+    if (callerThreadId <= 0 || processId <= 0) {
+        return false;
+    }
+    if (callerThreadId == processId) {
+        return true;
+    }
+#ifdef __APPLE__
+    return false;
+#else
+    std::error_code ignored;
+    return std::filesystem::exists(std::format("/proc/{}/task/{}", processId, callerThreadId), ignored);
+#endif
+}
+
 /*
  * Returns the name of the process which accessed the file system.
  */
@@ -486,7 +513,7 @@ static int openVFSfuse_open(const char *orig_path, struct fuse_file_info *fi)
 
     // The desktop client must not be blocked from accessing the file
     // to be able to overwrite it.
-    if (fuse_get_context()->pid == _jobs.desktopClientPid()) {
+    if (callerBelongsToProcess(fuse_get_context()->pid, _jobs.desktopClientPid())) {
         openvfsfuse_log(path, "open", res, "Desktop client tries to access, bypassing!");
     } else {
         if (const auto attribs = OpenVFS::PlaceHolderAttributes::fromAttributes(path)) {


### PR DESCRIPTION
<!-- Title: Compare the caller's process, not its thread, to the client's -->

`openVFSfuse_open()` exempts the desktop client from hydration blocking so that
the client can write the content it just downloaded without that write being
treated as a foreign access that needs hydrating. The check is:

```cpp
if (fuse_get_context()->pid == _jobs.desktopClientPid()) {
```

`fuse_context::pid` is the calling **thread** id. `desktopClientPid()` is the
**process** id the client announced in its `VERSION` reply. The two are equal
only when the client happens to do the write from its main thread.

A sync client downloads on worker threads, so in practice the exemption never
fires. The client's own hydration write is queued as a fresh hydration request,
which the client answers with another write, and `open()` deadlocks against the
hydration it is currently serving.

This is not specific to the client I was testing with: any client that does its
transfers off the main thread hits it.

### Reproduction

A stub client on the socket API, driving a real FUSE mount over a tree of
dehydrated placeholders, with the stub serving each `V2/HYDRATE_FILE` on its own
thread — which is what a real client does.

```
stub process id announced over VERSION:  54377
pids FUSE reported for the write threads: 54449 54546 54550 54553 54557 ...
all present under /proc/54377/task/       -> thread ids, not the tgid
"bypassing" log lines during the run:     0
```

Eight concurrent opens of dehydrated placeholders wedged the mount until
`hydrationTimeoutSeconds` expired, and not one `bypassing` line was logged.

With this change: eight `bypassing` lines and eight hydration requests, all
eight opens complete, every checksum matches the source, and the small files no
longer queue behind the 500 MB transfer.

### The change

A thread of the client is visible as `/proc/<pid>/task/<tid>`, so a single
`stat()` answers the question with nothing to read or parse. The direct
comparison stays as a fast path in front of it.

This check runs on every `open()` in the sync root, so its cost matters. It is
one `stat()` on a path that is already in the dentry cache, and it sits next to
`getcallername()`, which already does a `readlink("/proc/<pid>/exe")` on the same
code path — so this does not add a `/proc` access where there was none, it adds
a cheaper one alongside an existing one. Parsing `/proc/<pid>/status` for `Tgid:`
would work too and was my first attempt, but it means opening and reading a file
per `open()` where a `stat()` will do.

On platforms without `/proc` only the direct comparison applies, which leaves
them on exactly the previous behaviour.

### What I could not do

**macOS has the same bug and this does not fix it there.** The equivalent is
`proc_pidinfo()` with `PROC_PIDTBSDINFO`, whose `pbi_pid` gives the process id
for a thread. I have no macOS machine to test that on, so I left the platform on
its current behaviour rather than commit an untested path. Happy to add it if
someone can verify it.

There is also a race I did not try to close: a thread can exit between the FUSE
request and the `stat()`, and a pid can in principle be recycled. Both windows
existed before this change — `getcallername()` has the same exposure — and
closing them properly needs pidfds, which felt out of scope for a bug fix.

I also did not add a test. Reproducing this needs a client that writes from a
worker thread and a real mount; `socketthreadtest` (from #54) exercises the
socket layer, but the identity check lives on the FUSE side of the boundary and
I did not see a clean way to reach it from there. Suggestions welcome.

### Relationship to #54

Independent of it. The line this touches exists on `main` and #54 does not
modify it — its hunks are on either side. This applies cleanly to `main` on its
own, and rebases onto #54 without conflict. I found it while testing #54's
branch, which is the only reason the two are mentioned together.

### Environment

Linux 7.1.8 (CachyOS), gcc 16.2.1, libfuse 3.18.2, Btrfs. Built
`RelWithDebInfo`; `ctest` green.
