### PR TITLE
Do not print to stderr when a path has no placeholder attributes

### DIFF
--- a/src/openvfs/openvfs.cpp
+++ b/src/openvfs/openvfs.cpp
@@ -100,7 +100,6 @@ std::optional<OpenVFS::PlaceHolderAttributes> OpenVFS::PlaceHolderAttributes::fr
 {
     const auto data = Xattr::CPP::getxattr(absolutePath, OpenVFS::Constants::XAttributeNames::Data);
     if (!data.has_value()) {
-        std::cerr << "No placeholder attributes found for: " << absolutePath << std::endl;
         return std::nullopt;
     }
     return fromData(absolutePath, std::vector<uint8_t>{data.value().cbegin(), data.value().cend()});


### PR DESCRIPTION

Closes #57.

As suggested there — the message is gone and nothing else changes.

Having no placeholder attributes is an ordinary answer rather than a failure,
and the empty optional already carries it. Both callers in the FUSE layer
(`openvfsfuse.cpp:238` and `:527`) test the optional before using it, so nothing
depended on the message being printed.

`<iostream>` stays: the unregister failure further up the file still uses it.

Built and `ctest` passes on Arch, and it silences the case that led me here — a
KIO file manager listing a directory where something was just deleted was
collecting one line of stderr per lookup.
